### PR TITLE
Yurushi

### DIFF
--- a/name.json
+++ b/name.json
@@ -17,6 +17,8 @@
     "canonical": "Lucy",
     "preferred": "Lucy",
     "alternatives": [
+      "許し。",
+      "Yurushi",
       "Lusitania",
       "Liùsaidh",
       "Liusaidh",


### PR DESCRIPTION
As an alternative answer to the age old question "What is Lucy short for?"

In Japanese, Lucy is ルーシー。(Rūshī).

許し。 (Yurushi) means forgiveness.